### PR TITLE
Fix CoLM GPQA spotlight link

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
                         <a href="https://axrp.net/episode/2026/01/03/episode-47-david-rein-metr-time-horizons.html" target="_blank">
                             AXRP Podcast: David Rein on METR Time Horizons
                         </a>
-                        &mdash; A conversation on evaluation time horizons and how they relate to measuring AI progress.
+                        &mdash; A conversation about some of the subtle in-the-weeds details about METR's time horizon methodology.
                     </li>
 
                     <li>
@@ -72,7 +72,7 @@
                         <a href="https://www.youtube.com/watch?v=ZANbujPTvOY" target="_blank">
                             CoLM GPQA Spotlight Talk
                         </a>
-                        &mdash; Spotlight presentation for GPQA at the Conference on Language Modeling.
+                        &mdash; Spotlight presentation for GPQA at the first Conference on Language Modeling.
                     </li>
                     <li>
                         <strong>2024</strong> &mdash;

--- a/index.html
+++ b/index.html
@@ -37,6 +37,14 @@
                 <ul>
                     
                     <li>
+                        <strong>2026</strong> &mdash;
+                        <a href="https://axrp.net/episode/2026/01/03/episode-47-david-rein-metr-time-horizons.html" target="_blank">
+                            AXRP Podcast: David Rein on METR Time Horizons
+                        </a>
+                        &mdash; A conversation on evaluation time horizons and how they relate to measuring AI progress.
+                    </li>
+
+                    <li>
                         <strong>2025</strong> &mdash;
                         <a href="https://metr.org/blog/2025-08-12-research-update-towards-reconciling-slowdown-with-time-horizons/" target="_blank">
                             Research Update: Algorithmic vs. Holistic Evaluation
@@ -58,6 +66,13 @@
                             NYU Code Debates Update/Postmortem
                         </a>
                         &mdash; A write-up of what we learned from running AI-assisted debates with non-programmer judges on simple coding tasks.
+                    </li>
+                    <li>
+                        <strong>2024</strong> &mdash;
+                        <a href="https://www.youtube.com/watch?v=ZANbujPTvOY" target="_blank">
+                            CoLM GPQA Spotlight Talk
+                        </a>
+                        &mdash; Spotlight presentation for GPQA at the Conference on Language Modeling.
                     </li>
                     <li>
                         <strong>2024</strong> &mdash;


### PR DESCRIPTION
### Motivation
- Ensure the CoLM GPQA spotlight entry links to the official YouTube talk rather than an incorrect page. 
- Make recent appearances (AXRP podcast and CoLM spotlight) discoverable from the homepage. 
- Resolve the preview "Not Found" issue caused by the wrong URL. 

### Description
- Updated `index.html` to add the AXRP podcast entry pointing at `https://axrp.net/episode/2026/01/03/episode-47-david-rein-metr-time-horizons.html`. 
- Replaced the incorrect GPQA link with the official YouTube URL `https://www.youtube.com/watch?v=ZANbujPTvOY` for the CoLM GPQA Spotlight Talk in `index.html`. 
- Inserted both items into the existing "Other writing" list in chronological order. 

### Testing
- Served the site locally with `python -m http.server 8000` and verified the server responded. 
- Confirmed the homepage is reachable with `curl -fsS http://127.0.0.1:8000/` which exited successfully. 
- Captured a full-page screenshot using a Playwright script which produced `artifacts/axrp-colm-updates.png` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959abb19b3c83298d4a9d966f8e967d)