### PR TITLE
Add Netlify deploy preview workflow for pull requests

### DIFF
--- a/.github/workflows/netlify-deploy-preview.yml
+++ b/.github/workflows/netlify-deploy-preview.yml
@@ -1,0 +1,51 @@
+name: Netlify Deploy Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Netlify CLI
+        run: npm install -g netlify-cli
+
+      - name: Deploy preview
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: |
+          netlify deploy \
+            --dir=. \
+            --message="Deploy preview for ${{ github.event.pull_request.head.sha }}" \
+            --json > netlify-deploy-output.json
+          deploy_url=$(node -e "const fs=require('fs'); console.log(JSON.parse(fs.readFileSync('netlify-deploy-output.json','utf8')).deploy_url)")
+          echo "deploy_url=$deploy_url" >> "$GITHUB_OUTPUT"
+
+      - name: Comment deploy preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deployUrl = require('fs')
+              .readFileSync('netlify-deploy-output.json', 'utf8');
+            const url = JSON.parse(deployUrl).deploy_url;
+            const body = `✅ Netlify deploy preview: ${url}`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  publish = "."


### PR DESCRIPTION
### Motivation
- Provide deploy previews for pull requests so changes can be checked before merging.
- Use Netlify to host preview builds and post the deploy URL back to the PR as a comment.

### Description
- Add GitHub Actions workflow `.github/workflows/netlify-deploy-preview.yml` that runs on `pull_request` events and provisions Node 20.
- Use `netlify-cli` to run `netlify deploy --dir=. --json` and write output to `netlify-deploy-output.json`, then extract `deploy_url`.
- Comment the preview URL back on the pull request using `actions/github-script@v7` and set `deploy_url` as a workflow output.
- Add `netlify.toml` with `publish = "."` and require repository secrets `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` for deployment.

### Testing
- No automated tests were run; this change only adds a CI workflow and configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959b0f9cfec8329a8d32624a6ded8b5)